### PR TITLE
Sanitize uploaded filenames

### DIFF
--- a/handlers/extract.go
+++ b/handlers/extract.go
@@ -33,7 +33,8 @@ func ExtractHandler(c *gin.Context) {
 	}
 
 	// Save the file to a temporary location
-	savePath := filepath.Join("../media", file.Filename)
+	filename := utils.SanitizeFilename(file.Filename)
+	savePath := filepath.Join("../media", filename)
 	if err := c.SaveUploadedFile(file, savePath); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file"})
 		return

--- a/utils/sanitize.go
+++ b/utils/sanitize.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"path/filepath"
+	"regexp"
+)
+
+// SanitizeFilename cleans the filename by removing path elements and
+// allowing only letters, numbers, dots, hyphens and underscores.
+func SanitizeFilename(name string) string {
+	name = filepath.Base(name)
+	// Remove any character not allowed
+	re := regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+	return re.ReplaceAllString(name, "_")
+}


### PR DESCRIPTION
## Summary
- sanitize uploaded filenames by whitelisting allowed characters
- use sanitized filename in extract handler

## Testing
- `go test ./...` *(fails: ffprobe missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840bc5a47cc83278c3d710845905b1a